### PR TITLE
update support library to v28

### DIFF
--- a/share-plugin/gradle.conf
+++ b/share-plugin/gradle.conf
@@ -1,2 +1,2 @@
 [dependencies]
-    api ('com.android.support:support-v4:27.+')
+    api ('com.android.support:support-v4:28.+')


### PR DESCRIPTION
Updated the Support Library to v28 to prevent DuplicateClasses failure on Godot 3.2 Stable.